### PR TITLE
disable backup feature debug output

### DIFF
--- a/ftplugin/lsl.vim
+++ b/ftplugin/lsl.vim
@@ -13,7 +13,7 @@ setlocal foldmethod=syntax
 
 " Sync any saved lsl file to the directory specified in vimrc if 
 " one was specified.  Ignore if none
-echom strpart(getline(2),2)
+" echom strpart(getline(2),2)
 if strpart(getline(2),2) == "backup"
     let b:backupname = strpart(getline(1), 2)
     echom "Will be backed up as: " . b:backupname


### PR DESCRIPTION
Just disabling the debug output for your backup feature. Cheers for the plugin.
