### PR TITLE
fix folding for code blocks

### DIFF
--- a/syntax/lsl.vim
+++ b/syntax/lsl.vim
@@ -1116,7 +1116,7 @@ syn region lslString display
 syn match lslStringEscape display
 \ /\\t\|\\n/
 
-syn region lslBlock display
+syn region lslBlock
 \ start='{' end='}' fold transparent contains=ALL
 
 syn region lslParen display


### PR DESCRIPTION
Syntax based code folding (using `za` command etc) fixed for LSL code blocks.
