### PR TITLE
add commentstring for vim-commentary support

### DIFF
--- a/ftplugin/lsl.vim
+++ b/ftplugin/lsl.vim
@@ -11,6 +11,8 @@ setlocal autoindent
 setlocal foldenable
 setlocal foldmethod=syntax
 
+setlocal commentstring=//\ %s
+
 " Sync any saved lsl file to the directory specified in vimrc if 
 " one was specified.  Ignore if none
 " echom strpart(getline(2),2)


### PR DESCRIPTION
Had this commentstring in my config, so have moved it over to the plugin.
