### PR TITLE
Highlight preprocessor commands

### DIFF
--- a/syntax/lsl.vim
+++ b/syntax/lsl.vim
@@ -35,12 +35,12 @@ syntax keyword lslDebug
 syntax region lslDefine
 \ start='#define.*\|#undef.*' 
 \ end='$'
-\ contains=lslComment,lslCommentMulti
+\ contains=lslComment,lslCommentMulti,lslString
 
 syntax region lslInclude
 \ start='#include.*' 
 \ end='$'
-\ contains=lslComment,lslCommentMulti
+\ contains=lslComment,lslCommentMulti,lslString
 
 syntax region lslPreCondit
 \ start='#ifdef.*\|#ifndef.*\|#if.*\|#elif.*\|#else.*\|#endif.*' 

--- a/syntax/lsl.vim
+++ b/syntax/lsl.vim
@@ -31,6 +31,10 @@ syntax keyword lslTodo
 syntax keyword lslDebug
 \ debug Debug DEBUG temp Temp TEMP
 
+" PREPROCESSOR "
+syntax match lslPreprocessorCommand
+\ /#define.*\|#undef.*\|#ifdef.*\|#ifndef.*\|#if.*\|#elif.*\|#else.*\|#endif.*\|#warning.*\|#error.*\|#include.*/
+
 " FUNCTIONS "
 syn keyword lslFunction
 \ llAbs
@@ -1161,6 +1165,8 @@ syn match lslOperator display
 \ /\/\(\/\)\@!/
 
 " HIGHLIGHTING "
+highlight default link lslPreprocessorCommand Conditional
+
 highlight default link lslTodo          Todo
 highlight default link lslDebug         Special
 highlight default link lslComment       Comment

--- a/syntax/lsl.vim
+++ b/syntax/lsl.vim
@@ -35,7 +35,7 @@ syntax keyword lslDebug
 syntax region lslDefine
 \ start='^\s*\(#\)\s*\(define\|undef\)\>' 
 \ end='$'
-\ contains=lslComment,lslCommentMulti,lslString
+\ contains=lslComment,lslCommentMulti,lslString,lslNumber
 \ keepend
 
 syntax region lslInclude
@@ -47,13 +47,13 @@ syntax region lslInclude
 syntax region lslPreCondit
 \ start='^\s*\(#\)\s*\(ifdef\|ifndef\|if\|elif\|else\|endif\)\>' 
 \ end='$'
-\ contains=lslComment,lslCommentMulti
+\ contains=lslComment,lslCommentMulti,lslString,lslNumber
 \ keepend
 
 syntax region lslPreProc
 \ start='^\s*\(#\)\s*\(pragma\|line\|warning\|error\)\>' 
 \ end='$'
-\ contains=lslComment,lslCommentMulti
+\ contains=lslComment,lslCommentMulti,lslString,lslNumber
 \ keepend
 
 " FUNCTIONS "

--- a/syntax/lsl.vim
+++ b/syntax/lsl.vim
@@ -33,24 +33,28 @@ syntax keyword lslDebug
 
 " PREPROCESSOR "
 syntax region lslDefine
-\ start='#define.*\|#undef.*' 
+\ start='^\s*\(#\)\s*\(define\|undef\)\>' 
 \ end='$'
 \ contains=lslComment,lslCommentMulti,lslString
+\ keepend
 
 syntax region lslInclude
-\ start='#include.*' 
+\ start='^\s*\(#\)\s*\(include\)\>' 
 \ end='$'
 \ contains=lslComment,lslCommentMulti,lslString
+\ keepend
 
 syntax region lslPreCondit
-\ start='#ifdef.*\|#ifndef.*\|#if.*\|#elif.*\|#else.*\|#endif.*' 
+\ start='^\s*\(#\)\s*\(ifdef\|ifndef\|if\|elif\|else\|endif\)\>' 
 \ end='$'
 \ contains=lslComment,lslCommentMulti
+\ keepend
 
 syntax region lslPreProc
-\ start='#pragma.*\|#line.*\|#warning.*\|#error.*' 
+\ start='^\s*\(#\)\s*\(pragma\|line\|warning\|error\)\>' 
 \ end='$'
 \ contains=lslComment,lslCommentMulti
+\ keepend
 
 " FUNCTIONS "
 syn keyword lslFunction

--- a/syntax/lsl.vim
+++ b/syntax/lsl.vim
@@ -32,17 +32,25 @@ syntax keyword lslDebug
 \ debug Debug DEBUG temp Temp TEMP
 
 " PREPROCESSOR "
-syntax match lslDefine
-\ /#define.*\|#undef.*/
+syntax region lslDefine
+\ start='#define.*\|#undef.*' 
+\ end='$'
+\ contains=lslComment,lslCommentMulti
 
-syntax match lslInclude
-\ /#include.*/
+syntax region lslInclude
+\ start='#include.*' 
+\ end='$'
+\ contains=lslComment,lslCommentMulti
 
-syntax match lslPreCondit
-\ /#ifdef.*\|#ifndef.*\|#if.*\|#elif.*\|#else.*\|#endif.*/
+syntax region lslPreCondit
+\ start='#ifdef.*\|#ifndef.*\|#if.*\|#elif.*\|#else.*\|#endif.*' 
+\ end='$'
+\ contains=lslComment,lslCommentMulti
 
-syntax match lslPreProc
-\ /#pragma.*\|#line.*\|#warning.*\|#error.*/
+syntax region lslPreProc
+\ start='#pragma.*\|#line.*\|#warning.*\|#error.*' 
+\ end='$'
+\ contains=lslComment,lslCommentMulti
 
 " FUNCTIONS "
 syn keyword lslFunction

--- a/syntax/lsl.vim
+++ b/syntax/lsl.vim
@@ -32,8 +32,17 @@ syntax keyword lslDebug
 \ debug Debug DEBUG temp Temp TEMP
 
 " PREPROCESSOR "
-syntax match lslPreprocessorCommand
-\ /#define.*\|#undef.*\|#ifdef.*\|#ifndef.*\|#if.*\|#elif.*\|#else.*\|#endif.*\|#warning.*\|#error.*\|#include.*/
+syntax match lslDefine
+\ /#define.*\|#undef.*/
+
+syntax match lslInclude
+\ /#include.*/
+
+syntax match lslPreCondit
+\ /#ifdef.*\|#ifndef.*\|#if.*\|#elif.*\|#else.*\|#endif.*/
+
+syntax match lslPreProc
+\ /#pragma.*\|#line.*\|#warning.*\|#error.*/
 
 " FUNCTIONS "
 syn keyword lslFunction
@@ -1165,7 +1174,10 @@ syn match lslOperator display
 \ /\/\(\/\)\@!/
 
 " HIGHLIGHTING "
-highlight default link lslPreprocessorCommand Conditional
+highlight default link lslDefine        Macro
+highlight default link lslInclude       Include
+highlight default link lslPreCondit     PreCondit
+highlight default link lslPreProc       PreProc
 
 highlight default link lslTodo          Todo
 highlight default link lslDebug         Special


### PR DESCRIPTION
This PR enables highlighting for the LSL preprocessor commands.
It mimics the highlighting in Firestorm's native editor and adds some highlighting from vim's c.vim syntax to it.

There is still room for improvement but it is usable.