### PR TITLE
Fix block comment highlight

### DIFF
--- a/syntax/lsl.vim
+++ b/syntax/lsl.vim
@@ -1158,7 +1158,7 @@ syn match lslOperator display
 \ /[!%<>=*\+\-\|&\?\^~]/
 
 syn match lslOperator display
-\ /\/\(\/\)\@!/
+\ /\/\(\/\)@!/
 
 " HIGHLIGHTING "
 highlight default link lslTodo          Todo


### PR DESCRIPTION
I noticed highlighting was not working for block comments.
The `@` symbol was erronously escaped.